### PR TITLE
Ibc trace key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ name = "phase3"
 version = "0.1.0"
 dependencies = [
  "getrandom",
+ "namada_ibc",
  "namada_tx_prelude",
  "rlsf",
 ]

--- a/phase3/Cargo.toml
+++ b/phase3/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+namada_ibc.workspace = true
 namada_tx_prelude.workspace = true
 rlsf.workspace = true
 getrandom.workspace = true

--- a/phase3/src/lib.rs
+++ b/phase3/src/lib.rs
@@ -23,44 +23,44 @@ const IBC_TOKENS: [(
     (
         "channel-1",
         "uosmo",
-        MintTokenLimit::from_u64(10752692000000),       // 10,752,692 OSMO
+        MintTokenLimit::from_u64(10752692000000), // 10,752,692 OSMO
         ThroughtputTokenLimit::from_u64(2150539000000), // 2,150,539 OSMO
-        Some(Gas::from_u64(10)),                        // 10 uosmo / gas unit
+        Some(Gas::from_u64(10)),                  // 10 uosmo / gas unit
     ),
     (
         "channel-2",
         "uatom",
-        MintTokenLimit::from_u64(759878000000),         // 759,878 ATOM
-        ThroughtputTokenLimit::from_u64(151976000000),  // 151,976 ATOM
-        Some(Gas::from_u64(1)),                         // 1 uatom / gas unit;
+        MintTokenLimit::from_u64(759878000000), // 759,878 ATOM
+        ThroughtputTokenLimit::from_u64(151976000000), // 151,976 ATOM
+        Some(Gas::from_u64(1)),                 // 1 uatom / gas unit;
     ),
     (
         "channel-3",
         "utia",
-        MintTokenLimit::from_u64(1018330000000),        // 1,018,330 TIA
-        ThroughtputTokenLimit::from_u64(203666000000),  // 203,666 TIA
-        Some(Gas::from_u64(1)),                         // 1 utia / gas unit;
+        MintTokenLimit::from_u64(1018330000000), // 1,018,330 TIA
+        ThroughtputTokenLimit::from_u64(203666000000), // 203,666 TIA
+        Some(Gas::from_u64(1)),                  // 1 utia / gas unit;
     ),
     (
         "channel-0",
         "stuosmo",
-        MintTokenLimit::from_u64(8196721000000),        // 8,196,721 stOSMO
+        MintTokenLimit::from_u64(8196721000000), // 8,196,721 stOSMO
         ThroughtputTokenLimit::from_u64(1639344000000), // 1,639,344 stOSMO
-        Some(Gas::from_u64(10)),                        // 10 stuosmo / gas unit
+        Some(Gas::from_u64(10)),                 // 10 stuosmo / gas unit
     ),
     (
         "channel-0",
         "stuatom",
-        MintTokenLimit::from_u64(512821000000),         // 512,821 stATOM
-        ThroughtputTokenLimit::from_u64(102564000000),  // 102,564 stATOM
-        Some(Gas::from_u64(1)),                         // 1 stuatom / gas unit;
+        MintTokenLimit::from_u64(512821000000), // 512,821 stATOM
+        ThroughtputTokenLimit::from_u64(102564000000), // 102,564 stATOM
+        Some(Gas::from_u64(1)),                 // 1 stuatom / gas unit;
     ),
     (
         "channel-0",
         "stutia",
-        MintTokenLimit::from_u64(946970000000),         // 946,970 stTIA
-        ThroughtputTokenLimit::from_u64(189394000000),  // 189,394 stTIA
-        Some(Gas::from_u64(1)),                         // 1 stutia / gas unit;
+        MintTokenLimit::from_u64(946970000000), // 946,970 stTIA
+        ThroughtputTokenLimit::from_u64(189394000000), // 189,394 stTIA
+        Some(Gas::from_u64(1)),                 // 1 stutia / gas unit;
     ),
 ];
 
@@ -92,6 +92,12 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
         if let Some(gas) = can_be_used_as_gas {
             minimum_gas_price.insert(token_address.clone(), gas);
         }
+
+        // Write the ibc trace to storage to allow the discovery of the new assets by external tools (e.g. indexers)
+        let trace_hash = namada_ibc::trace::calc_hash(&ibc_denom);
+        let ibc_trace_key =
+            namada_ibc::storage::ibc_trace_key(token_address.to_string(), trace_hash);
+        ctx.write(&ibc_trace_key, ibc_denom.clone())?;
 
         // Add the ibc token to the masp token map
         token_map.insert(ibc_denom, token_address.clone());


### PR DESCRIPTION
Modifies the code for the phase 3 proposal to write an extra key, the ibc trace one, to allow external tools to discover new ibc assets before they have been transferred.