### PR TITLE
Replace canonical IBC token channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
             id: update-wasm
           - path: proposals/mainnet/update-staking-inflation-parameters
             id: update-staking-inflation-parameters
+          - path: proposals/mainnet/disable-ibc-chans-masp-migration
+            id: disable-ibc-chans-masp-migration
 
     env:
       GIT_LFS_SKIP_SMUDGE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "disable-ibc-chans-masp-migration"
+version = "1.0.0"
+dependencies = [
+ "getrandom 0.2.16",
+ "namada_tx_prelude",
+ "rlsf",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "proposals/mainnet_phases/phase5a",
     "proposals/mainnet_phases/phase5b",
     "proposals/mainnet/update-staking-inflation-parameters",
+    "proposals/mainnet/disable-ibc-chans-masp-migration",
     "proposals/testnet/add-uusdc-gas-token",
 ]
 

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/Cargo.toml
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "disable-ibc-chans-masp-migration"
+description = "Disable compromised IBC tokens and enable replacements on new channels."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+namada_tx_prelude.workspace = true
+rlsf.workspace = true
+getrandom.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/data.json
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/data.json
@@ -1,0 +1,15 @@
+{
+    "rust-version": "1.85.1",
+    "proposal": {
+        "title": "Disable compromised MASP IBC tokens and migrate to new channels",
+        "authors": "Heliax AG <hello@heliax.dev>",
+        "discussions-to": "",
+        "abstract": "Migrate IBC tokens off compromised MASP channels by disabling rate limits and inflation on the old channels and enabling fresh tokens on new channels.",
+        "motivation": "A MASP Groth16 proof verification bug allowed draining the pool while leaving notes unspent. The pool is fully compromised, so existing IBC tokens are disabled and replaced with fresh tokens originating from new IBC channels.",
+        "details": "For each (old_channel, base_token, new_channel) entry, this proposal zeroes the IBC rate limits and MASP inflation parameters of the old token, removes it from the gas-cost map and the MASP token map, then initializes rate limits, reward state (zeroed), and token-map entry for the new token.",
+        "author": "tnam1qxfj3sf6a0meahdu9t6znp05g8zx4dkjtgyn9gfu",
+        "voting_start_epoch": 6,
+        "voting_end_epoch": 12,
+        "activation_epoch": 18
+    }
+}

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -9,28 +9,68 @@ pub type MintLimit = u64;
 pub type ThroughputLimit = u64;
 
 const MIGRATIONS: [(ChannelId, BaseToken, ChannelId, MintLimit, ThroughputLimit); 7] = [
-    ("channel-1", "uosmo", "channel-101", 10752692000000, 2150539000000),
-    ("channel-2", "uatom", "channel-102", 759878000000, 151976000000),
-    ("channel-3", "utia", "channel-103", 1018330000000, 203666000000),
-    ("channel-0", "stuosmo", "channel-100", 8196721000000, 1639344000000),
-    ("channel-0", "stuatom", "channel-100", 512821000000, 102564000000),
-    ("channel-0", "stutia", "channel-100", 946970000000, 189394000000),
-    ("channel-5", "uusdc", "channel-105", 100000000000, 100000000000),
+    (
+        "channel-1",
+        "uosmo",
+        "channel-101",
+        10752692000000,
+        2150539000000,
+    ),
+    (
+        "channel-2",
+        "uatom",
+        "channel-102",
+        759878000000,
+        151976000000,
+    ),
+    (
+        "channel-3",
+        "utia",
+        "channel-103",
+        1018330000000,
+        203666000000,
+    ),
+    (
+        "channel-0",
+        "stuosmo",
+        "channel-100",
+        8196721000000,
+        1639344000000,
+    ),
+    (
+        "channel-0",
+        "stuatom",
+        "channel-100",
+        512821000000,
+        102564000000,
+    ),
+    (
+        "channel-0",
+        "stutia",
+        "channel-100",
+        946970000000,
+        189394000000,
+    ),
+    (
+        "channel-5",
+        "uusdc",
+        "channel-105",
+        100000000000,
+        100000000000,
+    ),
 ];
 
 #[transaction]
 fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
     let token_map_key = token::storage_key::masp_token_map_key();
-    let mut token_map: masp::TokenMap =
-        ctx.read(&token_map_key)?.unwrap_or_default();
+    let mut token_map: masp::TokenMap = ctx.read(&token_map_key)?.unwrap_or_default();
 
     let gas_cost_key = parameters_storage::get_gas_cost_key();
     let mut gas_cost: BTreeMap<Address, token::Amount> =
         ctx.read(&gas_cost_key)?.unwrap_or_default();
 
     for migration in &MIGRATIONS {
-        let (old_chan, base_token, new_chan, mint_limit, throughput_limit) =
-            migration;
+        let (old_chan, base_token, new_chan, mint_limit, throughput_limit) = migration;
         let old_denom = format!("transfer/{old_chan}/{base_token}");
         let new_denom = format!("transfer/{new_chan}/{base_token}");
         let old_token = ibc::ibc_token(&old_denom);
@@ -58,10 +98,7 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
 #[inline(always)]
 fn disable_old_ibc_rate_limits(ctx: &mut Ctx, old_token: &Address) -> TxResult {
     ctx.write(&ibc::mint_limit_key(old_token), token::Amount::zero())?;
-    ctx.write(
-        &ibc::throughput_limit_key(old_token),
-        token::Amount::zero(),
-    )?;
+    ctx.write(&ibc::throughput_limit_key(old_token), token::Amount::zero())?;
     Ok(())
 }
 
@@ -95,10 +132,7 @@ fn remove_old_gas_token(
 }
 
 #[inline(always)]
-fn remove_old_token_from_map(
-    token_map: &mut masp::TokenMap,
-    old_denom: &str,
-) {
+fn remove_old_token_from_map(token_map: &mut masp::TokenMap, old_denom: &str) {
     token_map.remove(old_denom);
 }
 
@@ -150,10 +184,6 @@ fn enable_new_masp_reward_state(ctx: &mut Ctx, new_token: &Address) -> TxResult 
 }
 
 #[inline(always)]
-fn add_new_token_to_map(
-    token_map: &mut masp::TokenMap,
-    new_denom: String,
-    new_token: Address,
-) {
+fn add_new_token_to_map(token_map: &mut masp::TokenMap, new_denom: String, new_token: Address) {
     token_map.insert(new_denom, new_token);
 }

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -78,14 +78,11 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
 
         disable_old_ibc_rate_limits(ctx, &old_token)?;
         disable_old_masp_inflation(ctx, &old_token)?;
-        let old_gas_price = remove_old_gas_token(&mut gas_cost, &old_token);
         remove_old_token_from_map(&mut token_map, &old_denom);
 
         enable_new_ibc_rate_limits(ctx, &new_token, *mint_limit, *throughput_limit)?;
         enable_new_masp_reward_state(ctx, &new_token)?;
-        if let Some(gas_price) = old_gas_price {
-            gas_cost.insert(new_token.clone(), gas_price);
-        }
+        update_gas_token(&mut gas_cost, &old_token, &new_token);
         add_new_token_to_map(&mut token_map, new_denom, new_token);
     }
 
@@ -124,11 +121,14 @@ fn disable_old_masp_inflation(ctx: &mut Ctx, old_token: &Address) -> TxResult {
 }
 
 #[inline(always)]
-fn remove_old_gas_token(
+fn update_gas_token(
     gas_cost: &mut BTreeMap<Address, token::Amount>,
     old_token: &Address,
-) -> Option<token::Amount> {
-    gas_cost.remove(old_token)
+    new_token: &Address,
+) {
+    if let Some(old_gas_price) = gas_cost.remove(old_token) {
+        gas_cost.insert(new_token.clone(), old_gas_price);
+    }
 }
 
 #[inline(always)]

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -38,11 +38,14 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
 
         disable_old_ibc_rate_limits(ctx, &old_token)?;
         disable_old_masp_inflation(ctx, &old_token)?;
-        remove_old_gas_token(&mut gas_cost, &old_token);
+        let old_gas_price = remove_old_gas_token(&mut gas_cost, &old_token);
         remove_old_token_from_map(&mut token_map, &old_denom);
 
         enable_new_ibc_rate_limits(ctx, &new_token, *mint_limit, *throughput_limit)?;
         enable_new_masp_reward_state(ctx, &new_token)?;
+        if let Some(gas_price) = old_gas_price {
+            gas_cost.insert(new_token.clone(), gas_price);
+        }
         add_new_token_to_map(&mut token_map, new_denom, new_token);
     }
 
@@ -87,8 +90,8 @@ fn disable_old_masp_inflation(ctx: &mut Ctx, old_token: &Address) -> TxResult {
 fn remove_old_gas_token(
     gas_cost: &mut BTreeMap<Address, token::Amount>,
     old_token: &Address,
-) {
-    gas_cost.remove(old_token);
+) -> Option<token::Amount> {
+    gas_cost.remove(old_token)
 }
 
 #[inline(always)]

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -1,0 +1,156 @@
+use std::collections::BTreeMap;
+
+use dec::Dec;
+use namada_tx_prelude::*;
+
+pub type ChannelId = &'static str;
+pub type BaseToken = &'static str;
+pub type MintLimit = u64;
+pub type ThroughputLimit = u64;
+
+const MIGRATIONS: [(ChannelId, BaseToken, ChannelId, MintLimit, ThroughputLimit); 7] = [
+    ("channel-1", "uosmo", "channel-101", 10752692000000, 2150539000000),
+    ("channel-2", "uatom", "channel-102", 759878000000, 151976000000),
+    ("channel-3", "utia", "channel-103", 1018330000000, 203666000000),
+    ("channel-0", "stuosmo", "channel-100", 8196721000000, 1639344000000),
+    ("channel-0", "stuatom", "channel-100", 512821000000, 102564000000),
+    ("channel-0", "stutia", "channel-100", 946970000000, 189394000000),
+    ("channel-5", "uusdc", "channel-105", 100000000000, 100000000000),
+];
+
+#[transaction]
+fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
+    let token_map_key = token::storage_key::masp_token_map_key();
+    let mut token_map: masp::TokenMap =
+        ctx.read(&token_map_key)?.unwrap_or_default();
+
+    let gas_cost_key = parameters_storage::get_gas_cost_key();
+    let mut gas_cost: BTreeMap<Address, token::Amount> =
+        ctx.read(&gas_cost_key)?.unwrap_or_default();
+
+    for migration in &MIGRATIONS {
+        let (old_chan, base_token, new_chan, mint_limit, throughput_limit) =
+            migration;
+        let old_denom = format!("transfer/{old_chan}/{base_token}");
+        let new_denom = format!("transfer/{new_chan}/{base_token}");
+        let old_token = ibc::ibc_token(&old_denom);
+        let new_token = ibc::ibc_token(&new_denom);
+
+        disable_old_ibc_rate_limits(ctx, &old_token)?;
+        disable_old_masp_inflation(ctx, &old_token)?;
+        remove_old_gas_token(&mut gas_cost, &old_token);
+        remove_old_token_from_map(&mut token_map, &old_denom);
+
+        enable_new_ibc_rate_limits(ctx, &new_token, *mint_limit, *throughput_limit)?;
+        enable_new_masp_reward_state(ctx, &new_token)?;
+        add_new_token_to_map(&mut token_map, new_denom, new_token);
+    }
+
+    ctx.write(&gas_cost_key, gas_cost)?;
+    ctx.write(&token_map_key, token_map)?;
+
+    Ok(())
+}
+
+#[inline(always)]
+fn disable_old_ibc_rate_limits(ctx: &mut Ctx, old_token: &Address) -> TxResult {
+    ctx.write(&ibc::mint_limit_key(old_token), token::Amount::zero())?;
+    ctx.write(
+        &ibc::throughput_limit_key(old_token),
+        token::Amount::zero(),
+    )?;
+    Ok(())
+}
+
+#[inline(always)]
+fn disable_old_masp_inflation(ctx: &mut Ctx, old_token: &Address) -> TxResult {
+    ctx.write(
+        &token::storage_key::masp_max_reward_rate_key(old_token),
+        Dec::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_kp_gain_key(old_token),
+        Dec::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_kd_gain_key(old_token),
+        Dec::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_locked_amount_target_key(old_token),
+        token::Amount::zero(),
+    )?;
+    Ok(())
+}
+
+#[inline(always)]
+fn remove_old_gas_token(
+    gas_cost: &mut BTreeMap<Address, token::Amount>,
+    old_token: &Address,
+) {
+    gas_cost.remove(old_token);
+}
+
+#[inline(always)]
+fn remove_old_token_from_map(
+    token_map: &mut masp::TokenMap,
+    old_denom: &str,
+) {
+    token_map.remove(old_denom);
+}
+
+#[inline(always)]
+fn enable_new_ibc_rate_limits(
+    ctx: &mut Ctx,
+    new_token: &Address,
+    mint_limit: MintLimit,
+    throughput_limit: ThroughputLimit,
+) -> TxResult {
+    ctx.write(
+        &ibc::mint_limit_key(new_token),
+        token::Amount::from_u64(mint_limit),
+    )?;
+    ctx.write(
+        &ibc::throughput_limit_key(new_token),
+        token::Amount::from_u64(throughput_limit),
+    )?;
+    Ok(())
+}
+
+#[inline(always)]
+fn enable_new_masp_reward_state(ctx: &mut Ctx, new_token: &Address) -> TxResult {
+    ctx.write(
+        &token::storage_key::masp_last_inflation_key(new_token),
+        token::Amount::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_last_locked_amount_key(new_token),
+        token::Amount::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_max_reward_rate_key(new_token),
+        Dec::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_locked_amount_target_key(new_token),
+        token::Amount::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_kp_gain_key(new_token),
+        Dec::zero(),
+    )?;
+    ctx.write(
+        &token::storage_key::masp_kd_gain_key(new_token),
+        Dec::zero(),
+    )?;
+    Ok(())
+}
+
+#[inline(always)]
+fn add_new_token_to_map(
+    token_map: &mut masp::TokenMap,
+    new_denom: String,
+    new_token: Address,
+) {
+    token_map.insert(new_denom, new_token);
+}

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -5,59 +5,15 @@ use namada_tx_prelude::*;
 
 pub type ChannelId = &'static str;
 pub type BaseToken = &'static str;
-pub type MintLimit = u64;
-pub type ThroughputLimit = u64;
 
-const MIGRATIONS: [(ChannelId, BaseToken, ChannelId, MintLimit, ThroughputLimit); 7] = [
-    (
-        "channel-1",
-        "uosmo",
-        "channel-101",
-        10752692000000,
-        2150539000000,
-    ),
-    (
-        "channel-2",
-        "uatom",
-        "channel-102",
-        759878000000,
-        151976000000,
-    ),
-    (
-        "channel-3",
-        "utia",
-        "channel-103",
-        1018330000000,
-        203666000000,
-    ),
-    (
-        "channel-0",
-        "stuosmo",
-        "channel-100",
-        8196721000000,
-        1639344000000,
-    ),
-    (
-        "channel-0",
-        "stuatom",
-        "channel-100",
-        512821000000,
-        102564000000,
-    ),
-    (
-        "channel-0",
-        "stutia",
-        "channel-100",
-        946970000000,
-        189394000000,
-    ),
-    (
-        "channel-5",
-        "uusdc",
-        "channel-105",
-        100000000000,
-        100000000000,
-    ),
+const MIGRATIONS: [(ChannelId, BaseToken, ChannelId); 7] = [
+    ("channel-1", "uosmo", "channel-101"),
+    ("channel-2", "uatom", "channel-102"),
+    ("channel-3", "utia", "channel-103"),
+    ("channel-0", "stuosmo", "channel-100"),
+    ("channel-0", "stuatom", "channel-100"),
+    ("channel-0", "stutia", "channel-100"),
+    ("channel-5", "uusdc", "channel-105"),
 ];
 
 #[transaction]
@@ -69,21 +25,15 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
     let mut gas_cost: BTreeMap<Address, token::Amount> =
         ctx.read(&gas_cost_key)?.unwrap_or_default();
 
-    for migration in &MIGRATIONS {
-        let (old_chan, base_token, new_chan, mint_limit, throughput_limit) = migration;
-        let old_denom = format!("transfer/{old_chan}/{base_token}");
-        let new_denom = format!("transfer/{new_chan}/{base_token}");
-        let old_token = ibc::ibc_token(&old_denom);
-        let new_token = ibc::ibc_token(&new_denom);
-
-        disable_old_ibc_rate_limits(ctx, &old_token)?;
-        disable_old_masp_inflation(ctx, &old_token)?;
-        remove_old_token_from_map(&mut token_map, &old_denom);
-
-        enable_new_ibc_rate_limits(ctx, &new_token, *mint_limit, *throughput_limit)?;
-        enable_new_masp_reward_state(ctx, &new_token)?;
-        update_gas_token(&mut gas_cost, &old_token, &new_token);
-        add_new_token_to_map(&mut token_map, new_denom, new_token);
+    for (old_chan, base_token, new_chan) in MIGRATIONS {
+        migrate_ibc_token(
+            ctx,
+            &mut token_map,
+            &mut gas_cost,
+            old_chan,
+            base_token,
+            new_chan,
+        )?;
     }
 
     ctx.write(&gas_cost_key, gas_cost)?;
@@ -93,9 +43,27 @@ fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {
 }
 
 #[inline(always)]
-fn disable_old_ibc_rate_limits(ctx: &mut Ctx, old_token: &Address) -> TxResult {
-    ctx.write(&ibc::mint_limit_key(old_token), token::Amount::zero())?;
-    ctx.write(&ibc::throughput_limit_key(old_token), token::Amount::zero())?;
+fn migrate_ibc_token(
+    ctx: &mut Ctx,
+    token_map: &mut masp::TokenMap,
+    gas_cost: &mut BTreeMap<Address, token::Amount>,
+    old_chan: ChannelId,
+    base_token: BaseToken,
+    new_chan: ChannelId,
+) -> TxResult {
+    let old_denom = format!("transfer/{old_chan}/{base_token}");
+    let new_denom = format!("transfer/{new_chan}/{base_token}");
+    let old_token = ibc::ibc_token(&old_denom);
+    let new_token = ibc::ibc_token(&new_denom);
+
+    disable_old_masp_inflation(ctx, &old_token)?;
+    remove_old_token_from_map(token_map, &old_denom);
+
+    update_ibc_rate_limits(ctx, &old_token, &new_token)?;
+    enable_new_masp_reward_state(ctx, &new_token)?;
+    update_gas_token(gas_cost, &old_token, &new_token);
+    add_new_token_to_map(token_map, new_denom, new_token);
+
     Ok(())
 }
 
@@ -137,20 +105,20 @@ fn remove_old_token_from_map(token_map: &mut masp::TokenMap, old_denom: &str) {
 }
 
 #[inline(always)]
-fn enable_new_ibc_rate_limits(
-    ctx: &mut Ctx,
-    new_token: &Address,
-    mint_limit: MintLimit,
-    throughput_limit: ThroughputLimit,
-) -> TxResult {
-    ctx.write(
-        &ibc::mint_limit_key(new_token),
-        token::Amount::from_u64(mint_limit),
-    )?;
-    ctx.write(
-        &ibc::throughput_limit_key(new_token),
-        token::Amount::from_u64(throughput_limit),
-    )?;
+fn update_ibc_rate_limits(ctx: &mut Ctx, old_token: &Address, new_token: &Address) -> TxResult {
+    let mint_limit: token::Amount = ctx
+        .read(&ibc::mint_limit_key(&old_token))?
+        .unwrap_or_default();
+    let throughput_limit: token::Amount = ctx
+        .read(&ibc::throughput_limit_key(&old_token))?
+        .unwrap_or_default();
+
+    ctx.write(&ibc::mint_limit_key(new_token), mint_limit)?;
+    ctx.write(&ibc::throughput_limit_key(new_token), throughput_limit)?;
+
+    ctx.write(&ibc::mint_limit_key(old_token), token::Amount::zero())?;
+    ctx.write(&ibc::throughput_limit_key(old_token), token::Amount::zero())?;
+
     Ok(())
 }
 

--- a/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
+++ b/proposals/mainnet/disable-ibc-chans-masp-migration/src/lib.rs
@@ -107,10 +107,10 @@ fn remove_old_token_from_map(token_map: &mut masp::TokenMap, old_denom: &str) {
 #[inline(always)]
 fn update_ibc_rate_limits(ctx: &mut Ctx, old_token: &Address, new_token: &Address) -> TxResult {
     let mint_limit: token::Amount = ctx
-        .read(&ibc::mint_limit_key(&old_token))?
+        .read(&ibc::mint_limit_key(old_token))?
         .unwrap_or_default();
     let throughput_limit: token::Amount = ctx
-        .read(&ibc::throughput_limit_key(&old_token))?
+        .read(&ibc::throughput_limit_key(old_token))?
         .unwrap_or_default();
 
     ctx.write(&ibc::mint_limit_key(new_token), mint_limit)?;


### PR DESCRIPTION
disabled compromised ibc tokens in the shielded pool, replacing them with new tokens (from new channels)

notes:
- we need to fill in the real values of the new channels
- we need to update the proposal json data, to change the proposer addr, etc